### PR TITLE
Update tree sitter and add ci/cd workflow

### DIFF
--- a/.github/workflows/lilypad.yml
+++ b/.github/workflows/lilypad.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: macOS-latest
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/lilypad.yml
+++ b/.github/workflows/lilypad.yml
@@ -21,7 +21,8 @@ jobs:
         toolchain: nightly-2025-03-29
         components: clippy, rustfmt
     - name: Build and test
-    - run: cargo fmt --check
-    - run: cargo clippy --release
-    - run: cargo build --release
-    - run: cargo test --release
+      run: |
+        cargo fmt --check
+        cargo clippy --release
+        cargo build --release
+        cargo test --release

--- a/.github/workflows/lilypad.yml
+++ b/.github/workflows/lilypad.yml
@@ -1,0 +1,27 @@
+name: lilypad
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: nightly-2025-03-29
+        components: clippy, rustfmt
+    - name: Build and test
+    - run: cargo fmt --check
+    - run: cargo clippy --release
+    - run: cargo build --release
+    - run: cargo test --release

--- a/.github/workflows/lilypad.yml
+++ b/.github/workflows/lilypad.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: nightly-2025-03-29
+        toolchain: nightly
         components: clippy, rustfmt
     - name: Build and test
       run: |

--- a/.github/workflows/publish_extension.yml
+++ b/.github/workflows/publish_extension.yml
@@ -22,6 +22,9 @@ jobs:
 
       - name: Install just
         run: cargo install just
+        
+      - name: Install LLVM
+        run: sudo apt-get update && sudo apt-get install -y llvm
 
       - name: Install Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/publish_extension.yml
+++ b/.github/workflows/publish_extension.yml
@@ -1,0 +1,44 @@
+name: Publish VSCode Extension
+
+on:
+  workflow_run:
+    workflows: ["lilypad"] # <-- name of your build workflow in lilypad.yml
+    types:
+      - completed
+
+jobs:
+  publish-extension:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+
+      - name: Install just
+        run: cargo install just
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install wasm-pack
+        uses: jetli/wasm-pack-action@v0.4.0
+
+      - name: Build WASM and VSCode extension
+        run: just wasm-vscode
+
+      - name: Install vsce
+        run: npm install -g @vscode/vsce
+
+      - name: Publish VSCode extension
+        if: github.repository == 'cacticouncil/lilypad'
+        run: |
+          cd lilypad-vscode
+          vsce publish --pat ${{ secrets.VSCE_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2836,9 +2836,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.25.8"
+version = "0.25.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7b8994f367f16e6fa14b5aebbcb350de5d7cbea82dc5b00ae997dd71680dd2"
+checksum = "ccd2a058a86cfece0bf96f7cce1021efef9c8ed0e892ab74639173e5ed7a34fa"
 dependencies = [
  "cc",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ regex = { version = "1.9", default-features = false, features = [
 ] }
 
 # tree sitter
-tree-sitter = "0.25"
+tree-sitter = "0.25.9"
 tree-sitter-language = "0.1"
 tree-sitter-python = "0.23"
 tree-sitter-java = "0.23"

--- a/src/block_editor/dragging/block_palette.rs
+++ b/src/block_editor/dragging/block_palette.rs
@@ -156,7 +156,7 @@ impl BlockPalette {
         let direction = if self.shown { Vec2::RIGHT } else { Vec2::LEFT };
         let close_response = ui.put(
             Rect::from_min_size(
-                rect.right_top() + Vec2::new(-1.0 * (H_PADDING + 30.0), V_PADDING - 5.0),
+                rect.right_top() + Vec2::new(-(H_PADDING + 30.0), V_PADDING - 5.0),
                 Vec2::splat(30.0),
             ),
             ArrowButton::new(direction),

--- a/src/block_editor/source/edit_generation.rs
+++ b/src/block_editor/source/edit_generation.rs
@@ -126,7 +126,7 @@ pub fn edit_for_insert_newline<'a>(
 
     // update source
     let indent: &str = &" ".repeat(next_indent);
-    let to_insert = format!("{}{}", linebreak, indent);
+    let to_insert = format!("{linebreak}{indent}");
 
     if !middle_of_bracket {
         let edit = TextEdit::new(Cow::Owned(to_insert), old_selection);
@@ -136,7 +136,7 @@ pub fn edit_for_insert_newline<'a>(
         // if in the middle of a bracket, insert an extra linebreak and indent
         // but only move the cursor to the newline in the middle
         let following_indent = " ".repeat(prev_indent);
-        let extra_to_insert = format!("{}{}{}", to_insert, linebreak, following_indent);
+        let extra_to_insert = format!("{to_insert}{linebreak}{following_indent}");
 
         let edit = TextEdit::new(Cow::Owned(extra_to_insert), old_selection);
         let new_selection =

--- a/src/block_editor/text_editor/block_dragging.rs
+++ b/src/block_editor/text_editor/block_dragging.rs
@@ -233,7 +233,7 @@ fn normalize_indent(mut block: String) -> String {
 
     // replace all other indents
     // works for both lf and crlf because they both end with lf
-    block = block.replace(&format!("\n{}", existing_indent), "\n");
+    block = block.replace(&format!("\n{existing_indent}"), "\n");
 
     block
 }
@@ -243,10 +243,10 @@ fn normalize_indent(mut block: String) -> String {
 fn set_indent(block: &str, new_indent_count: usize) -> String {
     // get the new indent
     let new_indent = " ".repeat(new_indent_count);
-    let new_linebreak_indent = format!("\n{}", new_indent);
+    let new_linebreak_indent = format!("\n{new_indent}");
 
     // add indent to start of string
-    let mut indented = format!("{}{}", new_indent, block);
+    let mut indented = format!("{new_indent}{block}");
 
     // replace all linebreaks with linebreak indents
     indented = indented.replace('\n', &new_linebreak_indent);

--- a/src/block_editor/text_editor/widget.rs
+++ b/src/block_editor/text_editor/widget.rs
@@ -459,9 +459,10 @@ impl TextEditor {
                         font,
                     );
                     if coord.line < source.text().len_lines() - 1
-                        && coord.col < source.text().line(coord.line).len_chars() {
-                            self.documentation.request_hover(coord.line, coord.col);
-                        }
+                        && coord.col < source.text().line(coord.line).len_chars()
+                    {
+                        self.documentation.request_hover(coord.line, coord.col);
+                    }
                 }
             }
         };

--- a/src/block_editor/text_editor/widget.rs
+++ b/src/block_editor/text_editor/widget.rs
@@ -111,7 +111,7 @@ impl TextEditor {
                     );
 
                     // draw gutter if in frame
-                    if offset.x > -1.0 * GUTTER_WIDTH {
+                    if offset.x > -GUTTER_WIDTH {
                         ui.put(
                             Rect::from_min_size(
                                 offset.to_pos2(),
@@ -175,11 +175,11 @@ impl TextEditor {
 
                     // draw documentation popup
                     let documentation = &self.documentation;
-                    if !(documentation.message == " ") && self.diagnostic_selection.is_none() {
+                    if (documentation.message != " ") && self.diagnostic_selection.is_none() {
                         let origin = self.documentation_popup.calc_origin(
                             documentation,
                             offset,
-                            &self.blocks.padding(),
+                            self.blocks.padding(),
                             font,
                         );
                         let line_count = documentation.message.lines().count();
@@ -428,10 +428,10 @@ impl TextEditor {
                         }
                     }
                 }
-                if self.documentation.message != " ".to_string() {
+                if self.documentation.message != " " {
                     let coord = pt_to_unbounded_text_coord(
                         pointer_pos - offset,
-                        &self.blocks.padding(),
+                        self.blocks.padding(),
                         font,
                     );
                     if !self.documentation.range.contains(coord, source.text()) {
@@ -452,17 +452,16 @@ impl TextEditor {
                         .iter()
                         .position(|d| d.range.contains(coord, source.text()));
                 }
-                if Self::mouse_still_for(0.5, ui) && self.documentation.message == " ".to_string() {
+                if Self::mouse_still_for(0.5, ui) && self.documentation.message == " " {
                     let coord = pt_to_unbounded_text_coord(
                         pointer_pos - offset,
-                        &self.blocks.padding(),
+                        self.blocks.padding(),
                         font,
                     );
-                    if coord.line < source.text().len_lines() - 1 {
-                        if coord.col < source.text().line(coord.line).len_chars() {
+                    if coord.line < source.text().len_lines() - 1
+                        && coord.col < source.text().line(coord.line).len_chars() {
                             self.documentation.request_hover(coord.line, coord.col);
                         }
-                    }
                 }
             }
         };

--- a/src/lang/highlighter.rs
+++ b/src/lang/highlighter.rs
@@ -117,12 +117,16 @@ impl<'tree> _QueryMatch<'_, 'tree> {
             _cursor: cursor,
             _id: m.id,
             _pattern_index: m.pattern_index as usize,
-            _captures: if m.capture_count > 0 { unsafe {
+            _captures: if m.capture_count > 0 {
+                unsafe {
                     slice::from_raw_parts(
                         m.captures.cast::<QueryCapture<'tree>>(),
                         m.capture_count as usize,
                     )
-                } } else { Default::default() },
+                }
+            } else {
+                Default::default()
+            },
         }
     }
 }

--- a/src/lang/highlighter.rs
+++ b/src/lang/highlighter.rs
@@ -117,14 +117,12 @@ impl<'tree> _QueryMatch<'_, 'tree> {
             _cursor: cursor,
             _id: m.id,
             _pattern_index: m.pattern_index as usize,
-            _captures: (m.capture_count > 0)
-                .then(|| unsafe {
+            _captures: if m.capture_count > 0 { unsafe {
                     slice::from_raw_parts(
                         m.captures.cast::<QueryCapture<'tree>>(),
                         m.capture_count as usize,
                     )
-                })
-                .unwrap_or_default(),
+                } } else { Default::default() },
         }
     }
 }

--- a/src/lsp/documentation.rs
+++ b/src/lsp/documentation.rs
@@ -1,4 +1,3 @@
-
 use crate::block_editor::text_range::{TextPoint, TextRange};
 use crate::vscode;
 


### PR DESCRIPTION
This push updates tree sitter to 0.25.9 (this updates the issue with endian.h). It also integrates a CI/CD workflow with github actions to run tests on commit and update the extension afterwards. 